### PR TITLE
Reduced MAX_NUM_PARTICIPANTS from 10 to 1 to save the RAM footprint.

### DIFF
--- a/include/rtps/config.h
+++ b/include/rtps/config.h
@@ -42,7 +42,7 @@ namespace rtps {
         const uint8_t NUM_STATELESS_READERS = 2;
         const uint8_t NUM_STATEFUL_READERS = 8;
         const uint8_t NUM_STATEFUL_WRITERS = 8;
-        const uint8_t MAX_NUM_PARTICIPANTS = 10;
+        const uint8_t MAX_NUM_PARTICIPANTS = 1;
         const uint8_t NUM_WRITERS_PER_PARTICIPANT = 16;
         const uint8_t NUM_READERS_PER_PARTICIPANT = 16;
         const uint8_t NUM_WRITER_PROXIES_PER_READER = 3;


### PR DESCRIPTION
Our configuration parameters for embedded RTPS seems to have larger than the requirement.
For example, MAX_NUM_PARTICIPANTS in include/rtps/config.h is set to 10, but I doubt if we require more than 1 participant (ROS node) for each board.
Applying this modification reduce the RAM footprint by 43Kbytes, and the demos seem to work as well with such configuration. And more, I have confirmed that we could support seed Arch Max as a MBed board, which have less RAM size(192 KByes) than NUCLOE-F429ZI(256 KBytes).
