### PR TITLE
Prototype of fragmented message support.

### DIFF
--- a/include/rtps/common/types.h
+++ b/include/rtps/common/types.h
@@ -38,6 +38,7 @@ namespace rtps {
 
 typedef uint16_t Ip4Port_t;
 typedef uint16_t DataSize_t;
+typedef uint32_t FragDataSize_t;
 typedef int8_t ParticipantId_t; // With UDP only 120 possible
 
 enum class EntityKind_t : uint8_t {

--- a/include/rtps/entities/StatefulWriter.h
+++ b/include/rtps/entities/StatefulWriter.h
@@ -46,6 +46,8 @@ public:
   void progress() override;
   const CacheChange *newChange(ChangeKind_t kind, const uint8_t *data,
                                DataSize_t size) override;
+  const CacheChange *newChangeCallback(ChangeKind_t kind,
+				       CacheChange::SerializerCallback func, FragDataSize_t size) override;
   void setAllChangesToUnsent() override;
   void onNewAckNack(const SubmessageAckNack &msg,
                     const GuidPrefix_t &sourceGuidPrefix) override;

--- a/include/rtps/entities/StatefulWriter.tpp
+++ b/include/rtps/entities/StatefulWriter.tpp
@@ -194,6 +194,13 @@ void StatefulWriterT<NetworkDriver>::removeReaderOfParticipant(
 }
 
 template <class NetworkDriver>
+const rtps::CacheChange *StatefulWriterT<NetworkDriver>::newChangeCallback(
+    ChangeKind_t kind, CacheChange::SerializerCallback func, FragDataSize_t size){
+  // Not supported
+  return nullptr;
+}
+
+template <class NetworkDriver>
 const rtps::CacheChange *StatefulWriterT<NetworkDriver>::newChange(
     ChangeKind_t kind, const uint8_t *data, DataSize_t size) {
   if (isIrrelevant(kind)) {

--- a/include/rtps/entities/StatelessWriter.h
+++ b/include/rtps/entities/StatelessWriter.h
@@ -48,6 +48,8 @@ public:
   void progress() override;
   const CacheChange *newChange(ChangeKind_t kind, const uint8_t *data,
                                DataSize_t size) override;
+  const CacheChange *newChangeCallback(ChangeKind_t kind,
+				       CacheChange::SerializerCallback func, FragDataSize_t size) override;
   void setAllChangesToUnsent() override;
   void onNewAckNack(const SubmessageAckNack &msg,
                     const GuidPrefix_t &sourceGuidPrefix) override;

--- a/include/rtps/entities/Writer.h
+++ b/include/rtps/entities/Writer.h
@@ -46,6 +46,8 @@ public:
   virtual void progress() = 0;
   virtual const CacheChange *newChange(ChangeKind_t kind, const uint8_t *data,
                                        DataSize_t size) = 0;
+  virtual const CacheChange *newChangeCallback(ChangeKind_t kind,
+					       CacheChange::SerializerCallback func, FragDataSize_t) = 0;
   virtual void setAllChangesToUnsent() = 0;
   virtual void onNewAckNack(const SubmessageAckNack &msg,
                             const GuidPrefix_t &sourceGuidPrefix) = 0;

--- a/include/rtps/storages/CacheChange.h
+++ b/include/rtps/storages/CacheChange.h
@@ -25,6 +25,7 @@ Author: i11 - Embedded Software, RWTH Aachen University
 #ifndef PROJECT_CACHECHANGE_H
 #define PROJECT_CACHECHANGE_H
 
+#include <functional>
 #include "rtps/common/types.h"
 #include "rtps/storages/PBufWrapper.h"
 
@@ -33,6 +34,10 @@ struct CacheChange {
   ChangeKind_t kind = ChangeKind_t::INVALID;
   SequenceNumber_t sequenceNumber = SEQUENCENUMBER_UNKNOWN;
   PBufWrapper data{};
+  typedef std::pair<uint8_t *, DataSize_t> SerializedBuf;
+  typedef std::function<SerializedBuf()> SerializerCallback;
+  SerializerCallback serializerCallback = nullptr;
+  FragDataSize_t sizeToBeSerialized;
 
   CacheChange() = default;
   CacheChange(ChangeKind_t kind, SequenceNumber_t sequenceNumber)

--- a/include/rtps/storages/SimpleHistoryCache.h
+++ b/include/rtps/storages/SimpleHistoryCache.h
@@ -47,6 +47,21 @@ public:
     return it == m_tail;
   }
 
+  const CacheChange *addChange(CacheChange::SerializerCallback func,
+                              FragDataSize_t size) {
+    CacheChange change;
+    change.kind = ChangeKind_t::ALIVE;
+    change.sizeToBeSerialized = size;
+    change.serializerCallback = func;
+    change.sequenceNumber = ++m_lastUsedSequenceNumber;
+
+    CacheChange *place = &m_buffer[m_head];
+    incrementHead();
+
+    *place = std::move(change);
+    return place;
+  }
+
   const CacheChange *addChange(const uint8_t *data, DataSize_t size) {
     CacheChange change;
     change.kind = ChangeKind_t::ALIVE;


### PR DESCRIPTION
This pull request is to add a fragmented data sending feature to embeddedRTPS.

I added a send-message-interface newChangeCallback() receiving a function object instead of a pointer to a buffer that includes a message to be sent (like the original "newChange()") .

The function object is expected to serialize one fragmented data each time embeddedRTPS sent the fragmented data to the lwIP layer.
The type of the function object has a return type, as below.
````
std::pair<uint8_t *, DataSize_t> 
````
where the first is the pointer to the fragmented data and the second is the size of the data. If there is no data to be fragmented, the function object returns zero size and embeddedRTPS perceives the end of the fragmented data.

The sender thread (progress()) of embeddedRTPS checks if each history cache has the function object, or not. If yes, it treat the history cache as a fragmented data and calls the function object. If no, it treat it as a non-fragmented data and do the exsiting procedure.

Limitation:
- Statefull Write is not supported. 
